### PR TITLE
Fix bison flash completion bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/js/game.js
+++ b/js/game.js
@@ -28,6 +28,7 @@ var spawnTime = 0;
 var startButton;
 var score = 0;
 var scoreText;
+var scoreBoard;
 var bisonWeight = 1500;
 
 function preload() {
@@ -215,7 +216,7 @@ function bisonHit(bison, bullet) {
   bison.setActive(false);
   bison.data.hit = true;
 
-  bison.flashTween = this.tweens.add({
+bison.flashTween = this.tweens.add({
     targets: bison,
     alpha: 0.5,
     ease: "Linear",
@@ -225,9 +226,19 @@ function bisonHit(bison, bullet) {
     onComplete: function () {
       if (bison.data.hit) {
         bison.setVisible(false);
+        bison.data.hit = false;
       }
     },
   });
+}
 
-  bison.data.hit = false;
+if (typeof module !== "undefined") {
+  module.exports = { bisonHit, __setTestVars };
+}
+
+function __setTestVars(vars) {
+  if ("scoreText" in vars) scoreText = vars.scoreText;
+  if ("scoreBoard" in vars) scoreBoard = vars.scoreBoard;
+  if ("score" in vars) score = vars.score;
+  if ("bisonWeight" in vars) bisonWeight = vars.bisonWeight;
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "bisonhunter",
+  "version": "1.0.0",
+  "description": "\"# bisonhunter\"",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.7.0"
+  }
+}

--- a/test/bisonHit.test.js
+++ b/test/bisonHit.test.js
@@ -1,0 +1,35 @@
+global.Phaser = { AUTO: 0, Game: function() {} };
+const { bisonHit, __setTestVars } = require('../js/game.js');
+
+test('bisonHit hides bison after tween completes', () => {
+  const bison = {
+    visible: true,
+    active: true,
+    data: {},
+    setVisible(v) { this.visible = v; },
+    setActive(v) { this.active = v; },
+  };
+
+  const bullet = { destroyed: false, destroy() { this.destroyed = true; } };
+
+  const context = {
+    tweens: {
+      killTweensOf() {},
+      add(config) { if (config.onComplete) config.onComplete(); return {}; },
+    },
+  };
+
+  const vars = {
+    score: 0,
+    scoreText: { setText: () => {} },
+    scoreBoard: { innerText: '' },
+    bisonWeight: 1500,
+  };
+  __setTestVars(vars);
+
+  bisonHit.call(context, bison, bullet);
+
+  expect(bison.visible).toBe(false);
+  expect(bison.data.hit).toBe(false);
+  expect(bullet.destroyed).toBe(true);
+});


### PR DESCRIPTION
## Summary
- define `scoreBoard` globally
- ensure bison becomes invisible once hit
- expose internal vars for tests
- add unit test for `bisonHit`
- setup Jest and ignore node artifacts

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68415a3ac8b4832486e2acd22823b3ad