### PR TITLE
Add high score tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,9 +3,9 @@
 <head>
 	<meta charset="UTF-8">
 	<title>Hunting Simulator</title>
-	<script src="js/phaser.min.js"></script>
-	<!-- <script src="js/game.js"></script> -->
-    <script src="js/game.js"></script>
+        <script src="js/phaser.min.js"></script>
+        <script src="js/highscore.js"></script>
+        <script src="js/game.js"></script>
 </head>
 <body>
 	<div id="game-container"></div>

--- a/js/game.js
+++ b/js/game.js
@@ -1,3 +1,11 @@
+var getHighScore, updateHighScore;
+if (typeof module !== 'undefined' && module.exports) {
+  ({ getHighScore, updateHighScore } = require('./highscore.js'));
+} else {
+  getHighScore = window.getHighScore;
+  updateHighScore = window.updateHighScore;
+}
+
 var config = {
   type: Phaser.AUTO,
   width: 800,
@@ -48,7 +56,8 @@ function create() {
   scoreBoard.style.padding = "10px";
   scoreBoard.style.fontSize = "32px";
   scoreBoard.style.fontWeight = "bold";
-  scoreBoard.innerText = "Score: 0 lbs";
+  scoreBoard.innerText =
+    "Score: 0 lbs (High: " + getHighScore() + " lbs)";
   document.body.appendChild(scoreBoard);
   scoreText = this.add.text(16, 16, "Score: 0 lbs", {
     fontSize: "32px",
@@ -209,7 +218,9 @@ function spawnBison() {
 function bisonHit(bison, bullet) {
   score += bisonWeight;
   scoreText.setText("Score: " + score + " lbs");
-  scoreBoard.innerText = "Score: " + score + " lbs";
+  var high = updateHighScore(score);
+  scoreBoard.innerText =
+    "Score: " + score + " lbs (High: " + high + " lbs)";
 
   bullet.destroy();
   this.tweens.killTweensOf(bison);

--- a/js/highscore.js
+++ b/js/highscore.js
@@ -1,0 +1,23 @@
+function getHighScore() {
+  if (typeof localStorage === 'undefined') {
+    return getHighScore._score || 0;
+  }
+  const stored = localStorage.getItem('highscore');
+  return stored ? parseInt(stored, 10) : 0;
+}
+
+function updateHighScore(newScore) {
+  const current = getHighScore();
+  if (newScore > current) {
+    if (typeof localStorage === 'undefined') {
+      getHighScore._score = newScore;
+    } else {
+      localStorage.setItem('highscore', newScore);
+    }
+  }
+  return getHighScore();
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { getHighScore, updateHighScore };
+}

--- a/tests/highscore.test.js
+++ b/tests/highscore.test.js
@@ -1,0 +1,24 @@
+const { getHighScore, updateHighScore } = require('../js/highscore.js');
+
+describe('high score management', () => {
+  beforeEach(() => {
+    // reset internal store
+    delete getHighScore._score;
+    if (typeof localStorage !== 'undefined' && localStorage.removeItem) {
+      localStorage.removeItem('highscore');
+    }
+  });
+
+  test('fetching high score when none exists returns 0', () => {
+    expect(getHighScore()).toBe(0);
+  });
+
+  test('updating the high score persists the larger value', () => {
+    updateHighScore(10);
+    expect(getHighScore()).toBe(10);
+    updateHighScore(5);
+    expect(getHighScore()).toBe(10);
+    updateHighScore(15);
+    expect(getHighScore()).toBe(15);
+  });
+});


### PR DESCRIPTION
## Summary
- implement persistent high score helpers
- test high score logic
- show the high score in the game
- load the new script in the page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68415c0306cc832491c5bc198be43260