### PR TITLE
Add endGame timer and tests

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -19,6 +19,8 @@ var config = {
 
 var game = new Phaser.Game(config);
 
+const GAME_DURATION_MS = 60000;
+
 var target;
 var bisonGroup;
 var bullets;
@@ -30,6 +32,9 @@ var score = 0;
 var scoreText;
 var scoreBoard;
 var bisonWeight = 1500;
+var spawnBisonEvent;
+var gameTimer;
+var gameOverOverlay;
 
 function preload() {
   this.load.image("target", "assets/target.png");
@@ -96,12 +101,14 @@ function startGame() {
     this
   );
 
-  this.time.addEvent({
+  spawnBisonEvent = this.time.addEvent({
     delay: 2000,
     callback: spawnBison,
     callbackScope: this,
     loop: true,
   });
+
+  gameTimer = this.time.delayedCall(GAME_DURATION_MS, endGame, [], this);
 }
 
 // Update function
@@ -232,8 +239,33 @@ bison.flashTween = this.tweens.add({
   });
 }
 
+function endGame() {
+  if (spawnBisonEvent) {
+    spawnBisonEvent.remove(false);
+  }
+  if (this.input && this.input.off) {
+    this.input.off('pointerdown');
+  }
+
+  if (!gameOverOverlay) {
+    gameOverOverlay = document.createElement('div');
+    gameOverOverlay.innerText = 'Game Over';
+    gameOverOverlay.style.position = 'absolute';
+    gameOverOverlay.style.left =
+      game.canvas.offsetLeft + game.canvas.width / 2 - 100 + 'px';
+    gameOverOverlay.style.top =
+      game.canvas.offsetTop + game.canvas.height / 2 - 50 + 'px';
+    gameOverOverlay.style.fontSize = '48px';
+    gameOverOverlay.style.fontWeight = 'bold';
+    gameOverOverlay.style.backgroundColor = 'rgba(0,0,0,0.7)';
+    gameOverOverlay.style.color = '#fff';
+    gameOverOverlay.style.padding = '20px';
+    document.body.appendChild(gameOverOverlay);
+  }
+}
+
 if (typeof module !== "undefined") {
-  module.exports = { bisonHit, __setTestVars };
+  module.exports = { bisonHit, endGame, __setTestVars };
 }
 
 function __setTestVars(vars) {
@@ -241,4 +273,6 @@ function __setTestVars(vars) {
   if ("scoreBoard" in vars) scoreBoard = vars.scoreBoard;
   if ("score" in vars) score = vars.score;
   if ("bisonWeight" in vars) bisonWeight = vars.bisonWeight;
+  if ("spawnBisonEvent" in vars) spawnBisonEvent = vars.spawnBisonEvent;
+  if ("game" in vars) game = vars.game;
 }

--- a/test/game.test.js
+++ b/test/game.test.js
@@ -1,0 +1,25 @@
+global.Phaser = { AUTO: 0, Game: function() {} };
+const { endGame, __setTestVars } = require('../js/game.js');
+
+test('endGame stops spawning bisons and disables shooting', () => {
+  const removeMock = jest.fn();
+  const spawnEvent = { remove: removeMock };
+  __setTestVars({ spawnBisonEvent: spawnEvent });
+
+  global.document = {
+    createElement: () => ({ style: {}, appendChild: jest.fn() }),
+    body: { appendChild: jest.fn() }
+  };
+
+  const fakeGame = { canvas: { offsetLeft: 0, width: 0, offsetTop: 0, height: 0 } };
+  __setTestVars({ game: fakeGame });
+
+  const context = {
+    input: { off: jest.fn() }
+  };
+
+  endGame.call(context);
+
+  expect(removeMock).toHaveBeenCalled();
+  expect(context.input.off).toHaveBeenCalledWith('pointerdown');
+});


### PR DESCRIPTION
## Summary
- add a GAME_DURATION_MS constant
- stop spawning and shooting after the timer via `endGame`
- show a game-over overlay on game end
- unit test `endGame` logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68415c04f278832488e4272ba850a6d5