### PR TITLE
Fix __setTestVars regression

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -296,6 +296,8 @@ function __setTestVars(vars) {
   if ("scoreBoard" in vars) scoreBoard = vars.scoreBoard;
   if ("score" in vars) score = vars.score;
   if ("bisonWeight" in vars) bisonWeight = vars.bisonWeight;
+  if ("spawnBisonEvent" in vars) spawnBisonEvent = vars.spawnBisonEvent;
+  if ("game" in vars) game = vars.game;
   if ("ammo" in vars) ammo = vars.ammo;
   if ("MAX_AMMO" in vars) MAX_AMMO = vars.MAX_AMMO;
   if ("bullets" in vars) bullets = vars.bullets;


### PR DESCRIPTION
## Summary
- reintroduce spawnBisonEvent and game assignments in `__setTestVars`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68415df9ecb48324892e859a8409ccd1