### PR TITLE
Fix Node require when Phaser absent

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -7,7 +7,7 @@ if (typeof module !== 'undefined' && module.exports) {
 }
 
 var config = {
-  type: Phaser.AUTO,
+  type: typeof Phaser !== 'undefined' ? Phaser.AUTO : 0,
   width: 800,
   height: 600,
   scene: {
@@ -25,7 +25,10 @@ var config = {
   },
 };
 
-var game = new Phaser.Game(config);
+var game;
+if (typeof Phaser !== 'undefined') {
+  game = new Phaser.Game(config);
+}
 
 const GAME_DURATION_MS = 60000;
 

--- a/tests/phaserOptional.test.js
+++ b/tests/phaserOptional.test.js
@@ -1,0 +1,12 @@
+const path = require('path');
+
+// Ensure a clean require state for game.js
+function loadGame() {
+  jest.resetModules();
+  return require('../js/game.js');
+}
+
+test('game module loads without Phaser defined', () => {
+  delete global.Phaser;
+  expect(() => loadGame()).not.toThrow();
+});


### PR DESCRIPTION
## Summary
- allow loading `game.js` without Phaser present
- test that the module can be required when Phaser isn't defined

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841607444708324ab7d22aa7d299a62