### PR TITLE
Fix asset loading paths

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -50,10 +50,11 @@ var gameTimer;
 var gameOverOverlay;
 
 function preload() {
-  this.load.image("target", "assets/target.png");
-  this.load.image("bs3", "assets/bs3.png");
+  this.load.setPath('assets');
+  this.load.image("target", "target.png");
+  this.load.image("bs3", "bs3.png");
   for (var i = 1; i <= 4; i++) {
-    this.load.image(`bg${i}`, `assets/bg${i}.png`);
+    this.load.image(`bg${i}`, `bg${i}.png`);
   }
 }
 

--- a/tests/preload.test.js
+++ b/tests/preload.test.js
@@ -1,0 +1,21 @@
+const path = require('path');
+
+// Helper to load game module and capture Phaser config
+function loadGameAndGetConfig() {
+  jest.resetModules();
+  global.Phaser = {
+    AUTO: 0,
+    Game: function(cfg) { global.__capturedConfig = cfg; },
+  };
+  require('../js/game.js');
+  return global.__capturedConfig;
+}
+
+test('preload sets asset base path', () => {
+  const config = loadGameAndGetConfig();
+  const mockSetPath = jest.fn();
+  const mockImage = jest.fn();
+  const scene = { load: { setPath: mockSetPath, image: mockImage } };
+  config.scene.preload.call(scene);
+  expect(mockSetPath).toHaveBeenCalledWith('assets');
+});


### PR DESCRIPTION
## Summary
- preload asset directory once for Phaser scene
- ensure preload sets base path with a new unit test

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6841627e7a5083249fa0cb79369a0a1a